### PR TITLE
added a glance_api_servers parameter to be passed through to cinder::glance

### DIFF
--- a/manifests/cinder/all.pp
+++ b/manifests/cinder/all.pp
@@ -37,7 +37,8 @@ class openstack::cinder::all(
   $use_syslog               = false,
   $log_facility             = 'LOG_USER',
   $debug                    = false,
-  $verbose                  = false
+  $verbose                  = false,
+  $glance_api_servers       = '127.0.0.1:9292'
 ) {
 
   ####### DATABASE SETUP ######
@@ -112,5 +113,9 @@ class openstack::cinder::all(
         warning("Unsupported volume driver: ${volume_driver}, make sure you are configuring this yourself")
       }
     }
+  }
+
+  class { '::cinder::glance':
+    glance_api_servers => $glance_api_servers
   }
 }

--- a/manifests/cinder/controller.pp
+++ b/manifests/cinder/controller.pp
@@ -32,7 +32,8 @@ class openstack::cinder::controller(
   $use_syslog               = false,
   $log_facility             = 'LOG_USER',
   $debug                    = false,
-  $verbose                  = false
+  $verbose                  = false,
+  $glance_api_servers       = '127.0.0.1:9292'
 ) {
 
   ####### DATABASE SETUP ######
@@ -80,4 +81,7 @@ class openstack::cinder::controller(
     enabled                => $scheduler_enabled,
   }
 
+  class { '::cinder::glance':
+    glance_api_servers => $glance_api_servers
+  }
 }

--- a/manifests/cinder/storage.pp
+++ b/manifests/cinder/storage.pp
@@ -20,7 +20,8 @@ class openstack::cinder::storage(
   $use_syslog            = false,
   $log_facility          = 'LOG_USER',
   $debug                 = false,
-  $verbose               = false
+  $verbose               = false,
+  $glance_api_servers    = '127.0.0.1:9292'
 ) {
 
   class {'::cinder':
@@ -69,5 +70,9 @@ class openstack::cinder::storage(
     default:  {
       warning("Unsupported volume driver: ${volume_driver}, make sure you are configuring this yourself")
     }
+  }
+
+  class { '::cinder::glance':
+    glance_api_servers => $glance_api_servers
   }
 }


### PR DESCRIPTION
added a glance_api_servers parameter to be passed through to cinder::glance

Without this bringing up an image based volume fails if glance and cinder are on different hosts, because cinder by default tries to use 127.0.0.1:9292 unless told to do otherwise via cinder.conf
