### PR TITLE
No nova-network on controller when multi-host is true

### DIFF
--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -196,7 +196,7 @@ class openstack::nova::controller (
     # Configure nova-network
     if $multi_host {
       nova_config { 'DEFAULT/multi_host': value => true }
-      $enable_network_service = true
+      $enable_network_service = false
     } else {
       nova_config { 'DEFAULT/multi_host': value => false }
       if $enabled {

--- a/spec/classes/openstack_controller_spec.rb
+++ b/spec/classes/openstack_controller_spec.rb
@@ -906,8 +906,8 @@ describe 'openstack::controller' do
         it { should contain_nova_config('DEFAULT/multi_host').with(:value => true)}
         it {should contain_class('nova::network').with(
           :create_networks   => true,
-          :enabled           => true,
-          :install_service   => true
+          :enabled           => false,
+          :install_service   => false
         )}
       end
 


### PR DESCRIPTION
- Enabling multi-host moves the nova netowrk service off
  the controller and onto the computes. The current logic is
  broken in that it always sets the nova::network class to
  install and enable the nova_network service making the
  conditional pointless. While it seems harmles to have the
  extra nova-network service on the controller it is not.
  When doing HA or using docker to contain services it causes
  extra services to need to be managed. It also pollutes the
  nova services catalog.
